### PR TITLE
added support for new status_whiteboard field

### DIFF
--- a/BugzillaQuery.php
+++ b/BugzillaQuery.php
@@ -85,6 +85,7 @@ class BugzillaQuery extends BSQLQuery {
     'sort'          => 'sort',
     'sortable'      => 'boolean',   # Whether the table is sortable or not
     'status'        => 'field',
+    'status_whiteboard' => 'field',
     'style'         => 'free',      # Define the CSS style to be applied to the table
     'to'            => 'field',
     'total'         => 'columns',


### PR DESCRIPTION
Status Whiteboad is a field that was added to Bugzilla a while ago, but is still not supported by BugzillaReports